### PR TITLE
Include tokio::runtime::Runtime as persistent parts of Rhiza Host, Nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ check.sh
 examples/get_ip.rs
 .gitignore
 examples/node_subscription.rs
-logs/*
+logs

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ sync.sh
 check.sh
 examples/get_ip.rs
 .gitignore
+examples/node_subscription.rs

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ check.sh
 examples/get_ip.rs
 .gitignore
 examples/node_subscription.rs
+logs/*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,18 +14,18 @@ name = "rhiza"
 serde = {version = "1", default-features = false, features = ["derive"]}
 postcard = {version = "0.7", features = ["alloc"]}
 heapless = "0.7"
+hex-slice = "0.1"
 # key value store, networking, and async
 sled = "0.34.6"
 pnet = "0.28"
 tokio = { version = "1.14.0", features = ["full", "rt-multi-thread"] }
-# command-line 
+# command-line utilties
 clap = "3"
-# logging, for tokio vs. otherwise
+# logging
 tracing = "0.1"
 tracing-subscriber = "0.3"
 tracing-appender = "0.2"
-#simplelog = "0.11"
-#log = {version = "0.4", features = ["std"]}
+
 
 [dev-dependencies]
 serial_test = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ heapless = "0.7"
 # key value store, networking, and async
 sled = "0.34.6"
 pnet = "0.28"
-tokio = { version = "1.14.0", features = ["full"] }
+tokio = { version = "1.14.0", features = ["full", "rt-multi-thread"] }
 # command-line 
-clap = "3.0.0-beta.5"
+clap = "3"
 
 [dev-dependencies]
 serial_test = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,14 @@ pnet = "0.28"
 tokio = { version = "1.14.0", features = ["full", "rt-multi-thread"] }
 # command-line 
 clap = "3"
+# logging, for tokio vs. otherwise
+tracing = "0.1"
+tracing-subscriber = "0.3"
+tracing-appender = "0.2"
+#simplelog = "0.11"
+#log = {version = "0.4", features = ["std"]}
 
 [dev-dependencies]
 serial_test = "0.5.1"
 rand = "0.8"
+geo = "0.18"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ fn main() {
 ```
 
 ### Node
-```rust
+```rust,no_run
 // A simple node (client-side)
 use rhiza::node::{Node, NodeConfig};
 use std::thread;
@@ -46,7 +46,7 @@ struct Coordinate {
 }
 
 fn main() {
-    // let addr = "192.168.8.105:25000"
+
     let addr = "127.0.0.1:25000".parse::<std::net::SocketAddr>().unwrap();
     let mut node: Node<Coordinate> = NodeConfig::new("pose").host_addr(addr).build().unwrap();
     node.connect().unwrap();
@@ -63,5 +63,4 @@ fn main() {
         println!("Got position: {:?}", result);
     }
 }
-
 ```

--- a/examples/host_and_single_node.rs
+++ b/examples/host_and_single_node.rs
@@ -1,0 +1,37 @@
+use rhiza::*;
+use std::thread;
+use std::time::Duration;
+
+fn main() {
+
+    // Set up logging
+    let file_appender = tracing_appender::rolling::minutely("logs/", "example");
+    let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
+    tracing_subscriber::fmt().with_writer(non_blocking).init();
+
+    let mut host: Host = HostConfig::new("lo")
+        .socket_num(25_000)
+        .store_filename("store")
+        .build()
+        .unwrap();
+    host.start().unwrap();
+    println!("Host should be running in the background");
+
+    // Get the host up and running
+    let addr = "127.0.0.1:25000".parse::<std::net::SocketAddr>().unwrap();
+    let mut node: Node<Pose> = NodeConfig::new("pose").host_addr(addr).build().unwrap();
+    node.connect().unwrap();
+
+    let mut result = Pose::default();
+
+    // Could get this by reading a GPS, for example
+    let pose = Pose { x: 4.0, y: 4.0 };
+
+    node.publish_to("pose", pose.clone()).unwrap();
+    thread::sleep(Duration::from_millis(1_000));
+    result = node.request("pose").unwrap();
+    println!("Got position: {:?}", result);
+
+    assert_eq!(pose, result);
+    host.stop().unwrap();
+}

--- a/examples/host_and_single_node.rs
+++ b/examples/host_and_single_node.rs
@@ -3,7 +3,6 @@ use std::thread;
 use std::time::Duration;
 
 fn main() {
-
     // Set up logging
     let file_appender = tracing_appender::rolling::minutely("logs/", "example");
     let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);

--- a/examples/multiple_nodes.rs
+++ b/examples/multiple_nodes.rs
@@ -1,9 +1,9 @@
-// use std::time::{sleep, Duration};
 use rhiza::host::*;
 use rhiza::node::{Node, NodeConfig};
 use rhiza::Pose;
-use tokio::task::JoinHandle;
-use tokio::time::{sleep, Duration};
+
+use std::thread;
+use std::time::Duration;
 
 const LABELS: [&str; 9] = [
     "all",
@@ -16,20 +16,18 @@ const LABELS: [&str; 9] = [
     "the_3",
     "view",
 ];
-
-#[tokio::main]
-async fn main() {
+fn main() {
     let mut host: Host = HostConfig::new("lo")
         .socket_num(25_000)
         .store_filename("store")
         .build()
         .unwrap();
-    host.start().await.unwrap();
+    host.start().unwrap();
 
     // Run n publish-subscribe loops in different processes
-    let mut handles: Vec<JoinHandle<()>> = Vec::new();
+    let mut handles: Vec<thread::JoinHandle<()>> = Vec::new();
     for i in 0..LABELS.len() {
-        let handle = tokio::spawn(async move {
+        let handle = thread::spawn(move || {
             let thread_num = i;
             let pose = Pose {
                 x: thread_num as f32,
@@ -38,24 +36,23 @@ async fn main() {
 
             // Create our node
             let addr = "127.0.0.1:25000".parse::<std::net::SocketAddr>().unwrap();
-            let mut node: Node<Pose> = NodeConfig::new(LABELS[i]).host_addr(addr).build();
-            node.connect().await.unwrap();
-            // sleep(Duration::from_millis(1)).await;
+            let mut node: Node<Pose> = NodeConfig::new(LABELS[i]).host_addr(addr).build().unwrap();
+            node.connect().unwrap();
 
-            loop {
-                node.publish_to("pose", pose.clone()).await.unwrap();
-                sleep(Duration::from_millis(i as u64)).await;
-                let result: Pose = node.request("pose").await.unwrap();
+            for i in 0..10 {
+                node.publish_to("pose", pose.clone()).unwrap();
+                thread::sleep(Duration::from_millis(i * 5 as u64));
+                let result: Pose = node.request("pose").unwrap();
                 println!("From thread {}, got: {:?}", thread_num, result);
             }
         });
         handles.push(handle);
     }
 
-    sleep(Duration::from_secs(3)).await;
+    thread::sleep(Duration::from_secs(3));
 
     for handle in handles {
-        handle.abort();
+        handle.join().unwrap();
     }
     host.stop().unwrap();
 }

--- a/examples/multiple_nodes.rs
+++ b/examples/multiple_nodes.rs
@@ -5,10 +5,11 @@ use rhiza::Pose;
 use std::thread;
 use std::time::Duration;
 
-const LABELS: [&str; 6] = ["ALL", "ALONG", "WATCHTOWER", "PRINCES", "KEPT", "VIEW"];
+// const LABELS: [&str; 6] = ["ALL", "ALONG", "WATCHTOWER", "PRINCES", "KEPT", "VIEW"];
+const LABELS: usize = 100;
 fn main() {
     // Set up logging
-    let file_appender = tracing_appender::rolling::minutely("logs/", "multiple_nodes");
+    let file_appender = tracing_appender::rolling::hourly("logs/", "multiple_nodes");
     let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
     tracing_subscriber::fmt().with_writer(non_blocking).init();
 
@@ -21,7 +22,7 @@ fn main() {
 
     // Run n publish-subscribe loops in different processes
     let mut handles: Vec<thread::JoinHandle<()>> = Vec::new();
-    for i in 0..LABELS.len() {
+    for i in 0..LABELS {
         let handle = thread::spawn(move || {
             let thread_num = i;
             let pose = Pose {
@@ -31,18 +32,26 @@ fn main() {
 
             // Create our node
             let addr = "127.0.0.1:25000".parse::<std::net::SocketAddr>().unwrap();
-            let mut node: Node<Pose> = NodeConfig::new(LABELS[i]).host_addr(addr).build().unwrap();
-            node.connect().unwrap();
+            let name = format!("LABEL_{}", i);
+            let mut node: Node<Pose> = NodeConfig::new(name).host_addr(addr).build().unwrap();
+            match node.connect() {
+                Ok(()) => {
+                    println!("NODE_{} connected successfully", i);
+                }
+                Err(e) => {
+                    panic!("NODE_{} did NOT connect successfully", i);
+                }
+            }
 
-            for i in 0..100 {
+            for i in 0..20 {
                 node.publish_to("pose", pose.clone()).unwrap();
                 thread::sleep(Duration::from_millis(i * 5 as u64));
                 let result: Pose = node.request("pose").unwrap();
-                println!("From thread {}, got: {:?}", thread_num, result);
+                // println!("From thread {}, got: {:?}", thread_num, result);
             }
         });
         handles.push(handle);
-        thread::sleep(Duration::from_millis(100));
+        thread::sleep(Duration::from_millis(1));
     }
 
     thread::sleep(Duration::from_secs(10));

--- a/examples/multiple_nodes.rs
+++ b/examples/multiple_nodes.rs
@@ -5,18 +5,9 @@ use rhiza::Pose;
 use std::thread;
 use std::time::Duration;
 
-const LABELS: [&str; 9] = [
-    "all",
-    "along",
-    "the_1",
-    "watchtower",
-    "the_2",
-    "princes",
-    "kept",
-    "the_3",
-    "view",
-];
+const LABELS: [&str; 6] = ["ALL", "ALONG", "WATCHTOWER", "PRINCES", "KEPT", "VIEW"];
 fn main() {
+    // Set up logging
     let file_appender = tracing_appender::rolling::minutely("logs/", "multiple_nodes");
     let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
     tracing_subscriber::fmt().with_writer(non_blocking).init();
@@ -51,6 +42,7 @@ fn main() {
             }
         });
         handles.push(handle);
+        thread::sleep(Duration::from_millis(100));
     }
 
     thread::sleep(Duration::from_secs(10));

--- a/examples/multiple_nodes.rs
+++ b/examples/multiple_nodes.rs
@@ -17,6 +17,10 @@ const LABELS: [&str; 9] = [
     "view",
 ];
 fn main() {
+    let file_appender = tracing_appender::rolling::minutely("logs/", "multiple_nodes");
+    let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
+    tracing_subscriber::fmt().with_writer(non_blocking).init();
+
     let mut host: Host = HostConfig::new("lo")
         .socket_num(25_000)
         .store_filename("store")
@@ -39,7 +43,7 @@ fn main() {
             let mut node: Node<Pose> = NodeConfig::new(LABELS[i]).host_addr(addr).build().unwrap();
             node.connect().unwrap();
 
-            for i in 0..10 {
+            for i in 0..100 {
                 node.publish_to("pose", pose.clone()).unwrap();
                 thread::sleep(Duration::from_millis(i * 5 as u64));
                 let result: Pose = node.request("pose").unwrap();
@@ -49,7 +53,7 @@ fn main() {
         handles.push(handle);
     }
 
-    thread::sleep(Duration::from_secs(3));
+    thread::sleep(Duration::from_secs(10));
 
     for handle in handles {
         handle.join().unwrap();

--- a/examples/node_subscription.rs
+++ b/examples/node_subscription.rs
@@ -1,3 +1,6 @@
+fn main() {}
+/*
+
 use rhiza::host::{Host, HostConfig};
 use rhiza::node::{Node, NodeConfig};
 use tokio::time::{sleep, Duration};
@@ -51,3 +54,5 @@ async fn main() {
 }
 
 fn create_subscription<T: rhiza::Message>(node: Node<T>, val: Arc<Mutex<T>>, interval: Duration) {}
+
+*/

--- a/examples/simple_host.rs
+++ b/examples/simple_host.rs
@@ -1,17 +1,17 @@
 use rhiza::host::{Host, HostConfig};
-use tokio::time::{sleep, Duration};
+use std::thread;
+use std::time::Duration;
 
-#[tokio::main]
-async fn main() {
+fn main() {
     let mut host: Host = HostConfig::new("lo")
         .socket_num(25_000)
         .store_filename("store")
         .build()
         .unwrap();
-    host.start().await.unwrap();
+    host.start().unwrap();
 
     // Other tasks can operate while the host is running in the background
-    sleep(Duration::from_secs(10)).await;
+    thread::sleep(Duration::from_secs(10));
 
     host.stop().unwrap();
 }

--- a/examples/simple_node.rs
+++ b/examples/simple_node.rs
@@ -1,5 +1,6 @@
 use rhiza::node::{Node, NodeConfig};
-use tokio::time::{sleep, Duration};
+use std::thread;
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
@@ -15,17 +16,15 @@ fn main() {
     let mut node: Node<Coordinate> = NodeConfig::new("pose").host_addr(addr).build().unwrap();
     node.connect().unwrap();
 
-    /*
     let c = Coordinate { x: 4.0, y: 4.0 };
-    node.publish_to("pose", c).await.unwrap();
+    node.publish_to("pose", c).unwrap();
 
     loop {
         // Could get this by reading a GPS, for example
         let c = Coordinate { x: 4.0, y: 4.0 };
-        node.publish_to("pose", c).await.unwrap();
-        sleep(Duration::from_millis(1_000)).await;
-        let result: Coordinate = node.request("pose").await.unwrap();
+        node.publish_to("pose", c).unwrap();
+        thread::sleep(Duration::from_millis(1_000));
+        let result: Coordinate = node.request("pose").unwrap();
         println!("Got position: {:?}", result);
     }
-    */
 }

--- a/examples/simple_node.rs
+++ b/examples/simple_node.rs
@@ -9,13 +9,13 @@ struct Coordinate {
     y: f32,
 }
 
-#[tokio::main]
-async fn main() {
+fn main() {
     // let addr = "192.168.8.105:25000"
     let addr = "127.0.0.1:25000".parse::<std::net::SocketAddr>().unwrap();
-    let mut node: Node<Coordinate> = NodeConfig::new("pose").host_addr(addr).build();
-    node.connect().await.unwrap();
+    let mut node: Node<Coordinate> = NodeConfig::new("pose").host_addr(addr).build().unwrap();
+    node.connect().unwrap();
 
+    /*
     let c = Coordinate { x: 4.0, y: 4.0 };
     node.publish_to("pose", c).await.unwrap();
 
@@ -27,4 +27,5 @@ async fn main() {
         let result: Coordinate = node.request("pose").await.unwrap();
         println!("Got position: {:?}", result);
     }
+    */
 }

--- a/src/bin/start_host.rs
+++ b/src/bin/start_host.rs
@@ -4,8 +4,7 @@ use tokio::signal;
 
 use clap::{App, Arg};
 
-#[tokio::main]
-async fn main() {
+fn main() -> ! {
     let matches = App::new("Rhiza Host")
         .version("0.1")
         .author("Christopher Moran <christopher.and.moran@gmail.com>")
@@ -42,12 +41,9 @@ async fn main() {
         .store_filename(store_filename)
         .build()
         .unwrap();
-    host.start().await.unwrap();
+    host.start().unwrap();
 
-    println!("Rhiza Host should be running in the background");
+    println!("Rhiza Host should be running");
     // Other tasks can operate while the host is running on it's own thread
-    signal::ctrl_c().await.unwrap();
-    println!("\nShutting down Rhiza Host");
-
-    host.stop().unwrap();
+    loop {}
 }

--- a/src/bin/start_host.rs
+++ b/src/bin/start_host.rs
@@ -3,8 +3,14 @@ use rhiza::host::{Host, HostConfig};
 use tokio::signal;
 
 use clap::{App, Arg};
+use tracing_appender;
+use tracing_subscriber;
 
 fn main() -> ! {
+    let file_appender = tracing_appender::rolling::minutely("logs/", "start_host");
+    let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
+    tracing_subscriber::fmt().with_writer(non_blocking).init();
+
     let matches = App::new("Rhiza Host")
         .version("0.1")
         .author("Christopher Moran <christopher.and.moran@gmail.com>")

--- a/src/host.rs
+++ b/src/host.rs
@@ -184,10 +184,6 @@ impl Host {
     }
 }
 
-fn pass_stream(stream: TcpStream) -> TcpStream {
-    stream
-}
-
 #[inline]
 fn handshake(stream: TcpStream) -> (TcpStream, String) {
     // Handshake

--- a/src/host.rs
+++ b/src/host.rs
@@ -5,6 +5,7 @@ use tokio::runtime::Runtime;
 use tokio::sync::Mutex; // as TokioMutex;
 use tokio::task::JoinHandle;
 // Tracing for logging
+use hex_slice::*;
 use tracing::*;
 // Postcard is the default de/serializer
 use postcard::*;
@@ -102,6 +103,7 @@ impl HostConfig {
 }
 
 impl Host {
+    
     #[tracing::instrument]
     pub fn start(&mut self) -> Result<(), Box<dyn Error + '_>> {
         let ip = crate::get_ip(&self.cfg.interface)?;
@@ -178,9 +180,13 @@ fn handshake(stream: TcpStream) -> (TcpStream, String) {
                 name = match std::str::from_utf8(&buf[..n]) {
                     Ok(name) => name.to_owned(),
                     Err(e) => {
-                        error!("Error occurred during handshake on host-side: {}", e);
-                        println!("Error during handshake (Host-side): {:?}", e);
-                        "placeholder".to_owned()
+                        error!("Error occurred during handshake on host-side: {} on byte string: {:?}, which in hex is: {:x}", e,&buf[..n],&buf[..n].as_hex());
+
+                        //let emsg = format!("Error parsing the following bytes: {:?}",&buf[..n]);
+                        //panic!("{}",emsg);
+
+                        // println!("Error during handshake (Host-side): {:?}", e);
+                        "HOST_CONNECTION_ERROR".to_owned()
                     }
                 };
                 break;
@@ -188,7 +194,8 @@ fn handshake(stream: TcpStream) -> (TcpStream, String) {
             Err(e) => {
                 if e.kind() == std::io::ErrorKind::WouldBlock {
                 } else {
-                    println!("Error: {:?}", e);
+                    error!("{:?}", e);
+                    // println!("Error: {:?}", e);
                 }
             }
         }

--- a/src/host.rs
+++ b/src/host.rs
@@ -103,7 +103,6 @@ impl HostConfig {
 }
 
 impl Host {
-    
     #[tracing::instrument]
     pub fn start(&mut self) -> Result<(), Box<dyn Error + '_>> {
         let ip = crate::get_ip(&self.cfg.interface)?;
@@ -121,6 +120,7 @@ impl Host {
 
             loop {
                 let (stream, stream_addr) = listener.accept().await.unwrap();
+                // TO_DO: The handshake function is not always happy
                 let (stream, name) = handshake(stream);
 
                 let db = db.clone();

--- a/src/node.rs
+++ b/src/node.rs
@@ -2,6 +2,8 @@ use tokio::net::TcpStream;
 use tokio::runtime::Runtime;
 use tokio::time::{sleep, Duration};
 
+use tracing::*;
+
 use std::ops::{Deref, DerefMut};
 use std::sync::{Arc, Mutex};
 
@@ -106,6 +108,7 @@ impl<T: Message + 'static> Node<T> {
                     }
                 }
             }
+            info!("{}: Successfully wrote connected to host", name);
         });
 
         Ok(())
@@ -136,6 +139,7 @@ impl<T: Message + 'static> Node<T> {
                 match stream.try_write(&packet_as_bytes) {
                     Ok(_n) => {
                         // println!("Successfully wrote {} bytes to host", n);
+                        info!("Successfully wrote {} bytes to host", _n);
                         break;
                     }
                     Err(e) => {
@@ -237,12 +241,12 @@ impl<T: Message + 'static> Node<T> {
 
     pub fn rebuild_config(&self) -> NodeConfig<T> {
         let name = self.name.clone();
-        dbg!(&name);
+        // dbg!(&name);
         let host_addr = match &self.stream {
             Some(stream) => stream.peer_addr().unwrap(),
             None => SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 25_000),
         };
-        dbg!(&host_addr);
+        // dbg!(&host_addr);
 
         NodeConfig {
             host_addr,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6,61 +6,60 @@ use rhiza::host::*;
 use rhiza::node::*;
 use rhiza::Pose;
 
-use tokio::time::{sleep, Duration};
+use std::thread;
+use std::time::Duration;
 
-#[tokio::main]
 #[test]
 #[serial]
-async fn integrate_host_and_single_node() {
+fn integrate_host_and_single_node() {
     let mut host: Host = HostConfig::new("lo")
         .socket_num(25_000)
         .store_filename("store")
         .build()
         .unwrap();
-    host.start().await.unwrap();
+    host.start().unwrap();
     println!("Host should be running in the background");
 
     // Get the host up and running
     let addr = "127.0.0.1:25000".parse::<std::net::SocketAddr>().unwrap();
-    let mut node: Node<Pose> = NodeConfig::new("pose").host_addr(addr).build();
-    node.connect().await.unwrap();
+    let mut node: Node<Pose> = NodeConfig::new("pose").host_addr(addr).build().unwrap();
+    node.connect().unwrap();
 
     let mut result = Pose::default();
 
     // Could get this by reading a GPS, for example
     let pose = Pose { x: 4.0, y: 4.0 };
 
-    node.publish_to("pose", pose.clone()).await.unwrap();
-    sleep(Duration::from_millis(1_000)).await;
-    result = node.request("pose").await.unwrap();
+    node.publish_to("pose", pose.clone()).unwrap();
+    thread::sleep(Duration::from_millis(1_000));
+    result = node.request("pose").unwrap();
     println!("Got position: {:?}", result);
 
     assert_eq!(pose, result);
     host.stop().unwrap();
 }
 
-#[tokio::main]
 #[test]
 #[serial]
-async fn request_non_existent_topic() {
+fn request_non_existent_topic() {
     let mut host: Host = HostConfig::new("lo")
         .socket_num(25_000)
         .store_filename("store")
         .build()
         .unwrap();
-    host.start().await.unwrap();
+    host.start().unwrap();
     println!("Host should be running in the background");
 
     // Get the host up and running
     let addr = "127.0.0.1:25000".parse::<std::net::SocketAddr>().unwrap();
-    let mut node: Node<Pose> = NodeConfig::new("pose").host_addr(addr).build();
-    node.connect().await.unwrap();
+    let mut node: Node<Pose> = NodeConfig::new("pose").host_addr(addr).build().unwrap();
+    node.connect().unwrap();
 
     for i in 0..5 {
         println!("on loop: {}", i);
-        let result: Result<Pose, Box<dyn Error>> = node.request("doesnt_exist").await;
+        let result: Result<Pose, Box<postcard::Error>> = node.request("doesnt_exist");
         dbg!(&result);
-        sleep(Duration::from_millis(50)).await;
+        thread::sleep(Duration::from_millis(50));
     }
 
     host.stop().unwrap();


### PR DESCRIPTION
At the moment, the Tokio runtime for both the Host and the Node are provided by annotating the `main()` function (or other) with `#[tokio::main]`, which per the Tokio docs ends up basically expanding into a `runtime::block_on( async {})` block anyway. This has been an issue when trying to integrate Rhiza into third-party libraries that may mean that the Runtime doesn't get carried around with the `Host` struct persistently, which causes tasks running on it to drop as well. 

I'm also just including this as part of a lesson-learned for this PR: per Alice Ryhl's advice on a Tokio forum: [don't wrap sockets in `Arc<Mutex<>>`, just pass a mutable reference to it](https://users.rust-lang.org/t/wrapping-tokio-tcpstream-in-arc-mutex-tcpstream/62771) 